### PR TITLE
Extra Mole data logging on hit/missed shot

### DIFF
--- a/Assets/Scripts/Game/GameDirector.cs
+++ b/Assets/Scripts/Game/GameDirector.cs
@@ -31,6 +31,9 @@ public class GameDirector : MonoBehaviour
     private float gameWarmUpTime = 3f;
 
     [SerializeField]
+    private float moleExpiringDuration = .2f;
+
+    [SerializeField]
     public TimeUpdateEvent timeUpdate;
 
     [SerializeField]
@@ -180,7 +183,7 @@ public class GameDirector : MonoBehaviour
 
     private void SpawnMole(float lifeTime, bool fakeCoeff)
     {
-        wallManager.ActivateMole(lifeTime, fakeCoeff);
+        wallManager.ActivateMole(lifeTime, moleExpiringDuration, fakeCoeff);
     }
 
     private void StartMoleTimer(float setTime = -1)

--- a/Assets/Scripts/Game/WallManager.cs
+++ b/Assets/Scripts/Game/WallManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 /*
 Spawns, references and activates the moles. Is the only component to directly interact with the moles.
@@ -32,8 +33,9 @@ public class WallManager : MonoBehaviour
     [SerializeField]
     private float heightOffset;
 
+    private class StateUpdateEvent: UnityEvent<bool, List<Mole>> {};
+    private StateUpdateEvent stateUpdateEvent = new StateUpdateEvent();
     private Vector3 wallCenter;
-
     private List<Mole> moles = new List<Mole>();
     private bool active = false;
 
@@ -62,14 +64,15 @@ public class WallManager : MonoBehaviour
     {
         active = false;
         DestroyWall();
+        stateUpdateEvent.Invoke(false, moles);
     }
 
     // Activates a random Mole for a given lifeTime and s fake or not
-    public void ActivateMole(float lifeTime, bool isFake)
+    public void ActivateMole(float lifeTime, float moleExpiringDuration, bool isFake)
     {
         if (!active) return;
 
-        GetRandomMole().Enable(lifeTime, isFake);
+        GetRandomMole().Enable(lifeTime, moleExpiringDuration, isFake);
     }
 
     // Pauses/unpauses the moles
@@ -79,6 +82,11 @@ public class WallManager : MonoBehaviour
         {
             mole.SetPause(pause);
         }
+    }
+
+    public UnityEvent<bool, List<Mole>> GetUpdateEvent()
+    {
+        return stateUpdateEvent;
     }
 
     // Returns a random, inactive Mole
@@ -134,6 +142,7 @@ public class WallManager : MonoBehaviour
                 moles.Add(mole);
             }
         }
+        stateUpdateEvent.Invoke(true, moles);
     }
 
     // Gets the Mole position depending on its index, the wall size (x and y axes of the vector3), and also on the curve coefficient (for the z axis).

--- a/Assets/Scripts/Logging/EventLogger.cs
+++ b/Assets/Scripts/Logging/EventLogger.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
 using System;
+using System.Globalization;
 
 /*
 Class dedicated to gather logs, organize, format and save them.
@@ -374,7 +375,7 @@ public class EventLogger : MonoBehaviour
         object testId;
         persistentLog.TryGetValue("ParticipantId", out participantId);
         persistentLog.TryGetValue("TestId", out testId);
-        uid = participantId.ToString() + testId.ToString() + System.DateTime.Now.ToString().Replace(" ", "").Replace("/", "").Replace(":", "");
+        uid = participantId.ToString() + testId.ToString() + System.DateTime.Now.ToString(new CultureInfo("en-GB")).Replace(" ", "").Replace("/", "").Replace(":", "");
     }
 
     // Converts the values of the parameters (in a "object format") to a string, formatting them to the
@@ -406,7 +407,7 @@ public class EventLogger : MonoBehaviour
     // Returns a time stamp including the milliseconds.
     private string GetTimeStamp()
     {
-        return System.DateTime.Now.ToString().Replace('/', '-') + "." + System.DateTime.Now.Millisecond.ToString();
+        return System.DateTime.Now.ToString(new CultureInfo("en-GB")).Replace('/', '-') + "." + System.DateTime.Now.Millisecond.ToString();
     }
 
     // Initialises the CSV file parameters (name and file path).

--- a/Assets/Scripts/Logging/WallStateTracker.cs
+++ b/Assets/Scripts/Logging/WallStateTracker.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/*
+Class keeping track of the state of the wall, meaning the state of the Mole. Keeps a list of the activated moles to
+calculate the closest active mole when a laser is shot and misses.
+*/
+
+public class WallStateTracker : MonoBehaviour
+{   
+    private List<Mole> activeMoles = new List<Mole>();
+
+    void Start()
+    {
+        FindObjectOfType<WallManager>().GetUpdateEvent().AddListener(WallStateUpdate);
+    }
+
+    // Returns the distance between the hit point and the closest active Mole.
+    public Vector2 GetClosestDistPointToMole(Vector3 point)
+    {
+        Vector3 closestMoleDist = Vector3.zero;
+
+        foreach(Mole mole in activeMoles)
+        {
+            if ((closestMoleDist == Vector3.zero) || (closestMoleDist.magnitude > Mathf.Abs(Vector3.Distance(point, mole.transform.position))))
+            {
+                closestMoleDist = (point - mole.transform.position);
+                closestMoleDist = new Vector3(Mathf.Abs(closestMoleDist.x), Mathf.Abs(closestMoleDist.y), Mathf.Abs(closestMoleDist.z));
+            }
+        }
+
+        return new Vector2(new Vector2(closestMoleDist.x, closestMoleDist.z).magnitude, closestMoleDist.y);
+    }
+
+    // Function called through an event when the WallManager initialises the wall (spawns the moles).
+    public void WallStateUpdate(bool isActivating, List<Mole> moleList)
+    {
+        if (isActivating)
+        {
+            foreach (Mole mole in moleList)
+            {
+                mole.GetUpdateEvent().AddListener(MoleStateUpdate);
+            }
+        }
+        else
+        {
+            activeMoles.Clear();
+        }
+    }
+
+    // Function called through an event whan a Mole's state changes.
+    public void MoleStateUpdate(bool isActivating, Mole concernedMole)
+    {
+        if (isActivating)
+        {
+            activeMoles.Add(concernedMole);
+        }
+        else
+        {
+            activeMoles.Remove(concernedMole);
+        }
+    }
+}

--- a/Assets/Scripts/Logging/WallStateTracker.cs.meta
+++ b/Assets/Scripts/Logging/WallStateTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb1666c4fb554314d8fccc49614c2b00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Testers/TestMole.cs
+++ b/Assets/Scripts/Testers/TestMole.cs
@@ -17,7 +17,7 @@ public class TestMole : MonoBehaviour
         if (Input.GetButtonDown("Jump"))
         {
             Debug.Log("Enable");
-            mole.Enable(2);
+            mole.Enable(2f, .2f);
         }
         if (Input.GetButtonDown("Fire1"))
         {


### PR DESCRIPTION
Moles which are not whacked in time are now logged as `Mole expired`.

Added a new event `Expired Mole Hit`, which is raised when an expired Mole (Mole which just passed from the enabled to the disabled state) is hit. A Mole stays in the expired state for a short duration (can be set in the editor, currently set to 0.2s) before entering in the disabled state.

If a shot doesn't hit an enabled or expiring Mole, a new `Mole Missed` event is raised. 

With the `Mole Missed` event comes five new log entries: ClosestActiveMoleDistance(X, Y) which corresponds to the distance between the hit point and the closest active Mole, on the X and Y axes, and HitPositionWorld(X, Y, Z) which corresponds to the current hit position in world coordinates and on the X, Y and Z axes.