### PR TITLE
FadingHelpers.cs class and FadingUtils.cs static class added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -395,3 +395,7 @@ ASALocalRun/
 healthchecksdb
 
 # End of https://www.gitignore.io/api/unity,visualstudio,visualstudiocode
+/Assets/Scenes/testFade.unity
+/Assets/Scenes/testFade.unity.meta
+/Assets/Scripts/Game/TestScript.cs
+/Assets/Scripts/Game/TestScript.cs.meta

--- a/Assets/Scripts/Game/FadingHelper.cs
+++ b/Assets/Scripts/Game/FadingHelper.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using System.Reflection;
+
+public class FadingHelper : MonoBehaviour
+{
+    [Header("Game Object To Fade:")]
+    [SerializeField]
+    [Tooltip("Drag and drop any text, images, sprites, canvas groups, 2D/3D objects to fade")]
+    private GameObject objToFade;
+
+    [SerializeField]
+    [Tooltip("Choose if you want the object to fade in, fade out")]
+    private FadeAction fadeAction = FadeAction.In;
+
+    [Header("Speed and Delay")]
+    [SerializeField]
+    [Tooltip("Time needed to fade the object")]
+    private float fadeTime = 1f;
+
+    [SerializeField]
+    [Tooltip("Delay before or between the fading")]
+    private float fadeDelay = 0f;
+
+    [Header("GameObject behaviour")]
+    [SerializeField]
+    [Tooltip("Should this object be enabled/disabled when fading in/out")]
+    private SetEnable setEnable = SetEnable.Off;
+
+    [SerializeField]
+    [Tooltip("Should this object fades in/out automatically when enabled/disabled")]
+    private AutoPlay autoPlay = AutoPlay.Off;
+
+    // Fades thanks to parameters from the inspector and using FadingUtils function
+    public void Fade()
+    {
+        FadingUtils.FadeRoutine(this, objToFade, fadeTime, fadeAction, fadeDelay, setEnable);
+    }
+
+    void OnEnable()
+    {
+        if (autoPlay==AutoPlay.On && fadeAction==FadeAction.In && objToFade!=null) // plays fading in effect when object is enabled
+        {
+            FadingUtils.FadeRoutine(this, objToFade, fadeTime, fadeAction, fadeDelay, setEnable);
+        }
+
+        if (autoPlay==AutoPlay.On && fadeAction==FadeAction.Out && objToFade!=null) // plays fading in effect when object is enabled
+        {
+            FadingUtils.FadeRoutine(this, objToFade, fadeTime, fadeAction, fadeDelay, setEnable);
+        }
+    }
+}

--- a/Assets/Scripts/Game/FadingHelper.cs.meta
+++ b/Assets/Scripts/Game/FadingHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4196e48bcf45544a8abc586a45088d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/FadingUtils.cs
+++ b/Assets/Scripts/Game/FadingUtils.cs
@@ -1,0 +1,191 @@
+﻿using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using Unity.Mathematics;
+
+public enum FadeAction 
+{
+    In,
+    Out
+}
+
+public enum SetEnable 
+{
+    On,
+    Off
+}
+
+public enum AutoPlay 
+{
+    On,
+    Off
+}
+
+public static class FadingUtils
+{
+    // Is mandatory if we want to fire coroutines from a static class
+    public static MonoBehaviour instance;
+
+    // Object Identifier
+    public enum ComponentToFade 
+    {
+        CanvasGroup,
+        Image,
+        SpriteRenderer,
+        MeshRenderer,
+        Text,
+        ERROR
+    }
+
+    // Helping functions
+    public static float GetAlpha(ComponentToFade toFade, GameObject Obj) 
+    {
+        float alphaToReturn = 0f;
+        switch (toFade)
+        {
+            case ComponentToFade.CanvasGroup:
+                alphaToReturn=Obj.GetComponent<CanvasGroup>().alpha;
+                break;
+            case ComponentToFade.Image:
+                alphaToReturn=Obj.GetComponent<Image>().color.a;
+                break;
+            case ComponentToFade.SpriteRenderer:
+                alphaToReturn=Obj.GetComponent<SpriteRenderer>().color.a;
+                break;
+            case ComponentToFade.MeshRenderer:
+                alphaToReturn=Obj.GetComponent<MeshRenderer>().material.color.a;
+                break;
+            case ComponentToFade.Text:
+                alphaToReturn=Obj.GetComponent<Text>().color.a;
+                break;
+        }
+        return alphaToReturn;
+    } // reads alpha value of an object
+
+    public static void SetAlpha(ComponentToFade toFade, GameObject Obj, float targetAlpha) 
+    {
+        switch (toFade)
+        {
+            case ComponentToFade.CanvasGroup:
+                Obj.GetComponent<CanvasGroup>().alpha=targetAlpha;
+                break;
+            case ComponentToFade.Image:
+                var compColor = Obj.GetComponent<Image>().color;
+                Obj.GetComponent<Image>().color=new Color(compColor.r, compColor.g, compColor.b, targetAlpha);
+                break;
+            case ComponentToFade.SpriteRenderer:
+                compColor = Obj.GetComponent<SpriteRenderer>().color;
+                Obj.GetComponent<SpriteRenderer>().color = new Color(compColor.r, compColor.g, compColor.b, targetAlpha);
+                break;
+            case ComponentToFade.MeshRenderer:
+                compColor = Obj.GetComponent<MeshRenderer>().material.color;
+                Obj.GetComponent<MeshRenderer>().material.color = new Color(compColor.r, compColor.g, compColor.b, targetAlpha);
+                break;
+            case ComponentToFade.Text:
+                compColor = Obj.GetComponent<Text>().color;
+                Obj.GetComponent<Text>().color = new Color(compColor.r, compColor.g, compColor.b, targetAlpha);
+                break;
+        }
+    } // sets alpha value of an object
+
+    // FadeUtils principal function call
+    public static void FadeRoutine(MonoBehaviour handler, GameObject Obj, float fadeTime, FadeAction fadeDirection, float fadeDelay = 0f,
+        SetEnable setEnable = SetEnable.Off) 
+    { 
+        instance=handler;
+        switch (fadeDirection)
+        {
+            case FadeAction.In:
+                instance.StartCoroutine(FadeInColor(Obj, FadeIdentification(Obj), fadeTime, fadeDelay, setEnable));
+                break;
+
+            case FadeAction.Out:
+                instance.StartCoroutine(FadeOutColor(Obj, FadeIdentification(Obj), fadeTime, fadeDelay, setEnable));
+                break;
+        }
+    }
+
+    // Identification function of the object to fade
+    public static ComponentToFade FadeIdentification(GameObject Obj) 
+    {
+        Component[] listComponents = Obj.GetComponents(typeof(Component)); // create a list of all components located inside the object to fade
+
+        int iterator = 0; // helps getting outside of the loop if no compatible component is found, once all components have been verified
+
+        while (iterator<listComponents.Length) // browse all components of the gameObject
+        {
+            if (listComponents[iterator] is CanvasGroup)
+                return ComponentToFade.CanvasGroup;
+            if (listComponents[iterator] is Image)
+                return ComponentToFade.Image;
+            if (listComponents[iterator] is SpriteRenderer)
+                return ComponentToFade.SpriteRenderer;
+            if (listComponents[iterator] is MeshRenderer)
+                return ComponentToFade.MeshRenderer;
+            if (listComponents[iterator] is Text)
+                return ComponentToFade.Text;
+            iterator++;
+        }
+        return ComponentToFade.ERROR; // if no compatible component is found
+    }
+
+    // Generic fading in function
+    public static IEnumerator FadeInColor(GameObject Obj, ComponentToFade componentToUse, float fadeTime, float fadeDelay, SetEnable setEnable) 
+    {
+        if (fadeDelay!=0) // play delay
+        {
+            yield return new WaitForSeconds(fadeDelay);
+        }
+
+        if (setEnable == SetEnable.On) // enabling
+        {
+            Obj.SetActive(true);
+        }
+
+        SetAlpha(componentToUse, Obj, 0); // setting up alpha to 0 so we can fade in
+
+        for (float i = 0;i<=fadeTime;i+=Time.deltaTime) // play fade effect
+        {
+            SetAlpha(componentToUse, Obj, FadeInAlpha(i, fadeTime, GetAlpha(componentToUse, Obj)));
+            yield return null;
+        }
+    }
+
+    // Generic fading out function
+    public static IEnumerator FadeOutColor(GameObject Obj, ComponentToFade componentToUse, float fadeTime, float fadeDelay, SetEnable setEnable) 
+    {
+        float baseAlpha = GetAlpha(componentToUse, Obj); // getting "base" alpha for of the object
+
+        if (fadeDelay!=0) // play delay
+        {
+            yield return new WaitForSeconds(fadeDelay);
+        }
+
+        SetAlpha(componentToUse, Obj, baseAlpha); // Setting alpha to base alpha so we can fade out
+
+        for (float i = 0;i<=fadeTime;i+=Time.deltaTime) // play fade effect
+        {
+            SetAlpha(componentToUse, Obj, FadeOutAlpha(i, fadeTime, GetAlpha(componentToUse, Obj)));
+            yield return null;
+        }
+
+        if (setEnable == SetEnable.On) // disabling
+        {
+            Obj.SetActive(false);
+        }
+    }
+
+    // Does the actual alpha shifting towards 1 (apparent object)
+    public static float FadeInAlpha(float iterator, float fadeTime, float alpha) 
+    {
+        alpha=math.remap(0, fadeTime, 0, 1, iterator);
+        return alpha;
+    }
+
+    // Does the actual alpha shifting towards 0 (transparent object)
+    public static float FadeOutAlpha(float iterator, float fadeTime, float alpha) 
+    {
+        alpha=1-math.remap(0, fadeTime, 0, 1, iterator);
+        return alpha;
+    }
+}

--- a/Assets/Scripts/Game/FadingUtils.cs.meta
+++ b/Assets/Scripts/Game/FadingUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0e5ecd1332ba6848bf8ea03dde42bac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,6 +8,7 @@
     "com.unity.ext.nunit": "1.0.0",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.2.0",
+    "com.unity.mathematics": "1.2.6",
     "com.unity.multiplayer-hlapi": "1.0.4",
     "com.unity.purchasing": "2.0.6",
     "com.unity.test-framework": "1.1.13",


### PR DESCRIPTION
Theses classes are used to handle different fading effects for different game objects.

Right now these scripts are not used by any game objects since they are subject to (a lot of?) change, but adding them won't do any harm to the existing project.

FadingHelper script can be attached to a game object and will look like this : 

![image](https://user-images.githubusercontent.com/94845309/195802602-dcb27d41-1ce0-4f0c-bcae-e46456117aa6.png)

Here is the purpose of the different parameters : 

- objToFade : drag and drop here the game object that you want to fade in or fade out
- Play Automatically : is still a work in progress, but will be used to fade in or fade out objects when they are enabled/disabled
- Fade in speed : ratio from 0 to 2 increasing/decreasing fading in effect speed
- Fade out speed : ratio from 0 to 2 increasing/decreasing fading out effect speed
- Fade delay : gives a delay between a fade in and a fade out
- Fade action : is used to setup which fade affect you are interrested in for the current gameobject the script is attached to


These scripts can be found in the project hierarchy here : **Assets>Scripts>Game**.