### PR TITLE
Bug fixed : WallManager: Mole states are not reset when game stops

### DIFF
--- a/Assets/Scripts/Moles/DiskMole.cs
+++ b/Assets/Scripts/Moles/DiskMole.cs
@@ -145,6 +145,7 @@ public class DiskMole : Mole
     {
         PlayAnimation("EnableDisable");
         meshMaterial.color = disabledColor;
+        meshMaterial.mainTexture = textureDisabled;
     }
 
     // Plays a sound.


### PR DESCRIPTION
Bug fixed thanks to the adding of **meshMaterial.mainTexture = textureDisabled;** code line in **PlayReset( )** function of the diskMole script.

The problem was due to the texture of the mole not updating when the game was reset. Now it should work as intended.

Before the bug fix : (circle still appearing after stopping the game)

![bugnotfixed](https://user-images.githubusercontent.com/94845309/195840681-f091bb09-90b9-470d-8d25-598003c5e577.gif)


After the bug fix : (circle disappearing after stopping the game)

![bugFixMoleNotDisappearing](https://user-images.githubusercontent.com/94845309/195840359-97848f3d-ff4a-4843-ab71-5e13bc1e7f42.gif)
