### PR TITLE
Fix CurrentMoleToHitID mismatch

### DIFF
--- a/Assets/Scripts/Logging/EventLogger.cs
+++ b/Assets/Scripts/Logging/EventLogger.cs
@@ -137,11 +137,14 @@ public class EventLogger : MonoBehaviour
                 //loggingManager.NewFilestamp();
                 break;
             case "Mole Spawned":
-                SaveEventDatas(datas, true, true);
                 UpdateCurrentMoleLog(datas);
-                break;
-            case "Fake Mole Spawned":
                 SaveEventDatas(datas, true, true);
+                break;
+            case "DistractorRight Mole Spawned":
+                SaveEventDatas(datas);
+                break;
+            case "DistractorLeft Mole Spawned":
+                SaveEventDatas(datas);
                 break;
             case "Mole Missed":
                 datas = AddClosestActiveMole(datas);
@@ -149,7 +152,15 @@ public class EventLogger : MonoBehaviour
                 break;
             case "Mole Hit":
             case "Mole Expired":
-            case "Fake Mole Expired":
+                UpdateCurrentMoleLog(datas);
+                SaveEventDatas(datas, true, true);
+                break;
+            case "DistractorRight Mole Expired":
+                SaveEventDatas(datas);
+                break;
+            case "DistractorLeft Mole Expired":
+                SaveEventDatas(datas);
+                break;
             case "Wrong Mole Hit":
                 if (currentMoleLog.ContainsKey("CurrentMoleId"))
                 {


### PR DESCRIPTION
The problem was that we saved the currentMoleID before to update its value. Therefore, for the first mole that spawned, we had a null value. Moreover, I've also modified the fake mole case because now we use distractor left or right instead of fake mole in the event type.

New Result :  
![image](https://user-images.githubusercontent.com/73820233/199250291-b0c500d5-8625-4ea1-9221-9c66ec8b796a.png)
