### PR TITLE
Location Mole.cs : Moles not spawning when launching a game

### DIFF
--- a/Assets/Scripts/Moles/Mole.cs
+++ b/Assets/Scripts/Moles/Mole.cs
@@ -76,9 +76,10 @@ public abstract class Mole : MonoBehaviour
 
     public void SetVisibility(bool isVisible)
     {
-        foreach(Transform child in transform)
+        foreach (Transform child in transform)
         {
-            child.GetComponent<Renderer>().enabled = isVisible;
+            if (child.GetComponent<Renderer>()!=null)
+                child.GetComponent<Renderer>().enabled=isVisible;
         }
     }
 


### PR DESCRIPTION
While working on animation feedback for the moles, I encountered a new bug where moles don't spawn anymore when launching a game.

It happened because a new line of code have been added in mole.cs, looking for renderer in child objects of the moles. If no renderer is found, it loops infinitely.

I've only added a if statement, verifying that there is indeed a renderer in the object and it fixed the bug.

See the function in question : 

![image](https://user-images.githubusercontent.com/94845309/200776310-a8511ee8-f09c-411a-a961-2a4aee2dbbff.png)
