### PR TITLE
SampleLogger : Fix performance issue by pausing the game multiple times

### DIFF
--- a/Assets/Scripts/Logging/SampleLogger.cs
+++ b/Assets/Scripts/Logging/SampleLogger.cs
@@ -31,6 +31,9 @@ public class SampleLogger : MonoBehaviour
     private TrackerHub trackerHub;
     private LoggingManager loggingManager;
 
+    private bool isLoggingStarted = false;
+
+
     // private Dictionary<string, Dictionary<int, string>> logs = new Dictionary<string, Dictionary<int, string>>();
 
     // private int logCount = 0;
@@ -84,17 +87,23 @@ public class SampleLogger : MonoBehaviour
         }
     }
 
-    public void StartLogging() {
+    public void StartLogging()
+    {
+        if (isLoggingStarted) return; // If the sample logger is already started, return. To avoid some useless GC alloc.
+
         trackerHub.StartTrackers();
-        //InitFile();
         StartCoroutine("SampleLog", samplingFrequency);
+        //InitFile();
+        isLoggingStarted = true;
     }
 
-    public void FinishLogging() {
+    public void FinishLogging()
+    {
         trackerHub.StopTrackers();
         StopCoroutine("SampleLog");
         //SaveCsvLogs();
         //ResetLogs();
+        isLoggingStarted = false;
     }
 
     // Generates a "logs" row (see class description) from the given datas. Adds mandatory parameters and 


### PR DESCRIPTION
I've just created a state into SampleLogger because when you pause the game with the built-in button : it increase it's calls to the GC by 36% constantly every time. This cause terrible lags during playing. 

This updates is to avoid a new instantiation of SampleLogger...

But we may need to create a singleton in earlier version I guess [by following this ref, for example](https://gamedevbeginner.com/singletons-in-unity-the-right-way/).