### PR TITLE
PatternPlayer: Avoid removal doing traversal

### DIFF
--- a/Assets/Scripts/Patterns/PatternPlayer.cs
+++ b/Assets/Scripts/Patterns/PatternPlayer.cs
@@ -175,8 +175,24 @@ public class PatternPlayer: MonoBehaviour
         // If there are no more moles left, continue.
         if (patternInterface.GetTargetsList().Count > 0) {
             // Clear disabled and popped moles from targetsList
-            foreach (var mole in patternInterface.GetTargetsList().Where(mole => mole.Value.GetState() != Mole.States.Enabled)) {
-                patternInterface.RemoveFromTargetsList(mole.Value.GetId());
+            //foreach (var mole in patternInterface.GetTargetsList().Where(mole => mole.Value.GetState() != Mole.States.Enabled))
+            //{
+            //    patternInterface.RemoveFromTargetsList(mole.Value.GetId());
+            //}
+
+            var molesToRemove = new List<int>(); // assuming the id is of type int
+
+            foreach (var mole in patternInterface.GetTargetsList())
+            {
+                if (mole.Value.GetState() != Mole.States.Enabled)
+                {
+                    molesToRemove.Add(mole.Value.GetId());
+                }
+            }
+
+            foreach (var moleId in molesToRemove)
+            {
+                patternInterface.RemoveFromTargetsList(moleId);
             }
             return;
         }


### PR DESCRIPTION
This pull request addresses an issue with the current implementation where items are being removed from a collection while iterating over it.

Iterating over a collection while removing items from it is not a recommended practice, as it can lead to unexpected behavior and bugs.

So we split the existing loop into two separate loops:
One for iterating over the collection and identifying items to be removed.
Another for actually removing those items from the collection.