### PR TITLE
 Enhance Debugging by Including Line Numbers in Test Pattern Error Messages

### DIFF
--- a/Assets/Scripts/Patterns/PatternInterface.cs
+++ b/Assets/Scripts/Patterns/PatternInterface.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 using System.Globalization;
 
@@ -79,120 +79,75 @@ public class PatternInterface : MonoBehaviour
     }
 
     // Plays an action
-    public void PlayAction(Dictionary<string, string> action)
+    public void PlayAction(Dictionary<string, string> action, int lineNumber = 0)
     {
         string[] keys = new string[action.Keys.Count];
         action.Keys.CopyTo(keys, 0);
 
         // If one of the argument is "RAND", replaces it with the random variable.
-        foreach(string key in keys)
+        foreach (string key in keys)
         {
             if (action[key] == "RAND") action[key] = randVar.ToString();
         }
 
-        // Matches the "FUNCTION" key, corresponding to the action to do.
-        switch(action["FUNCTION"])
+        try
         {
-                        
-            case "START":
-                CallPlay();
-                break;
-            
-            case "STOP":
-                CallStop();
-                break;
-            
-            case "WALL":
-                try
-                {
+            // Matches the "FUNCTION" key, corresponding to the action to do.
+            switch (action["FUNCTION"])
+            {
+                case "START":
+                    CallPlay();
+                    break;
+
+                case "STOP":
+                    CallStop();
+                    break;
+
+                case "WALL":
                     SetWall(action);
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in WALL: " + e.Message);
-                }
-                break;
-            
-            case "MOLE":
-                try
-                {
+                    break;
+
+                case "MOLE":
                     Debug.Log(action["X"] + action["Y"]);
                     SetMole(action["X"], action["Y"], action["LIFETIME"]);
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in MOLE: " + e.Message);
-                }
-                break;
-            
-            case "DISTRACTOR":
-                try
-                {
+                    break;
+
+                case "DISTRACTOR":
                     SetDistractor(action["X"], action["Y"], action["LIFETIME"], action["TYPE"]);
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in MOLE: " + e.Message);
-                }
-                break;
-            
-            case "DIFFICULTY":
-                try
-                {
+                    break;
+
+                case "DIFFICULTY":
                     SetDifficulty(action["SPEED"]);
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in DIFFICULTY: " + e.Message);
-                }
-                break;
-            
-            case "MODIFIER":
-                try
-                {
+                    break;
+
+                case "MODIFIER":
                     SetModifier(action);
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in MODIFIER: " + e.Message);
-                }
-                break;
+                    break;
 
-            case "SEGMENT":
-                try
-                {
+                case "SEGMENT":
                     SetSegment(action["ID"], action["LABEL"]);
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in SEGMENT: " + e.Message);
-                }
-                break;
-            
-            case "MESSAGE":
-                try
-                {
-                    SetMessage(action["LABEL"], action["TIME"]);
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in SEGMENT: " + e.Message);
-                }
-                break;
+                    break;
 
-            case "RANDGEN":
-                try
-                {
+                case "MESSAGE":
+                    SetMessage(action["LABEL"], action["TIME"]);
+                    break;
+
+                case "RANDGEN":
                     RegenRand(ParseFloat(action["STARTVALUE"]), ParseFloat(action["ENDVALUE"]), bool.Parse(action["ISINT"]));
-                }
-                catch(System.Exception e)
-                {
-                    Debug.LogError("Error in RANDGEN: " + e.Message);
-                }
-                break;
-                
+                    break;
+
+                default:
+                    Debug.LogWarning($"Unknown test pattern statement {action["FUNCTION"]}");
+                    break;
+            }
+        }
+        catch (System.Exception e)
+        {
+            // Log the error message along with the exact stack trace.
+            Debug.LogError($"Error in {action["FUNCTION"]} line {lineNumber} : {e.Message}\nStackTrace: {e.StackTrace}");
         }
     }
+
 
     // Calls the GameDirector to start the game
     public void CallPlay()

--- a/Assets/Scripts/Patterns/PatternPlayer.cs
+++ b/Assets/Scripts/Patterns/PatternPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 using System;
@@ -124,12 +124,11 @@ public class PatternPlayer: MonoBehaviour
         // Clear any moles remaining in the MolesIdList.
         patternInterface.ClearMolesList();
 
+        int currentLineNumber = 1;
         foreach (Dictionary<string, string> action in pattern[sortedKeys[playIndex]])
         {
-            // As the pattern interfaces plays the actions,
-            // new moles are added to the MoleIdList by PatternInterface.
-            //Debug.Log(action["FUNCTION"]);
-            patternInterface.PlayAction(new Dictionary<string, string>(action));
+            currentLineNumber++;
+            patternInterface.PlayAction(new Dictionary<string, string>(action), currentLineNumber);
         }
 
         if (playIndex < sortedKeys.Count - 1)


### PR DESCRIPTION
## Pull Request:  Enhance Debugging by Including Line Numbers in Test Pattern Error Messages

### Summary:
This pull request enhances the debug error messages in the test pattern file by including the line numbers where the error occurred.

### Changes:
- Modified `PatternInterface.cs` to accept an additional parameter `lineNumber` in the `PlayAction` method.
- Updated the error logging in the `PlayAction` method to include the line number.
- Modified `PatternPlayer.cs` to pass the current line number to the `PlayAction` method.