### PR TITLE
PointerType handling in PatternInterface

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -248,46 +248,6 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!21 &4280377
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _AlphaTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - PixelSnap: 0
-    - _EnableExternalAlpha: 0
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _Flip: {r: 1, g: 1, b: 1, a: 1}
-    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
-  m_BuildTextureStacks: []
 --- !u!1 &8760673
 GameObject:
   m_ObjectHideFlags: 0
@@ -1520,20 +1480,20 @@ MonoBehaviour:
   hideWallLeftMat: {fileID: 2100000, guid: 8ba1e2f7fb1dd5d4391a27cf51779fdb, type: 2}
   hideWallSlider: {fileID: 1543034552}
   prismEffectSlider: {fileID: 846140473}
-  rightController: {fileID: 1561852222}
-  rightControllerVisuals:
-  - {fileID: 1561814569}
-  - {fileID: 5357536993665756143}
   mirrorControllerR: {fileID: 269806455}
   mirrorControllerL: {fileID: 1374817400}
   wallManager: {fileID: 930846565}
   motorSpaceManager: {fileID: 1699109192}
-  leftController: {fileID: 1561696157}
+  leftController: {fileID: 1561621275}
+  leftControllerContainer: {fileID: 8704797489886666503}
   leftControllerVisuals:
   - {fileID: 1561831793}
   - {fileID: 1651983710}
+  rightController: {fileID: 1561852221}
   rightControllerContainer: {fileID: 6190571099507785273}
-  leftControllerContainer: {fileID: 8704797489886666503}
+  rightControllerVisuals:
+  - {fileID: 1561814569}
+  - {fileID: 5357536993665756143}
   controllerOffsetSlider: {fileID: 1262535085}
   prismOffsetObject: {fileID: 493209114}
   viveCamera: {fileID: 20000015556788213}
@@ -1556,7 +1516,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &59209617
 GameObject:
@@ -2619,171 +2579,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 94899828}
   m_CullTransparentMesh: 0
---- !u!43 &108454097
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 1.65, y: 0, z: 1.275}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: 0000c03f0ad7233c000090bf000000000000803f0000803f0000803f00000000000000000000c0bf0ad7233c000090bf000000000000803f0000803f0000803f0000803f000000000000c0bf0ad7233c0000903f000000000000803f0000803f0000803f00000000000000000000c03f0ad7233c0000903f000000000000803f0000803f0000803f0000803f000000003333d33f0ad7233c3333a3bf000000000000803f0000803f00000000000000000000803f3333d3bf0ad7233c3333a3bf000000000000803f0000803f000000000000803f0000803f3333d3bf0ad7233c3333a33f000000000000803f0000803f00000000000000000000803f3333d33f0ad7233c3333a33f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 1.65, y: 0, z: 1.275}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &108588310
 GameObject:
   m_ObjectHideFlags: 0
@@ -3895,7 +3690,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!850595691 &168956745
 LightingSettings:
@@ -19370,6 +19165,46 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!21 &1066846489
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - PixelSnap: 0
+    - _EnableExternalAlpha: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
 --- !u!1 &1067670280
 GameObject:
   m_ObjectHideFlags: 0
@@ -29687,11 +29522,11 @@ GameObject:
   m_Component:
   - component: {fileID: 1561499463}
   - component: {fileID: 114000010020215491}
+  - component: {fileID: 1561696157}
+  - component: {fileID: 114000010020215490}
   - component: {fileID: 114000010020215489}
   - component: {fileID: 1561696159}
   - component: {fileID: 1561696162}
-  - component: {fileID: 1561696157}
-  - component: {fileID: 114000010020215490}
   m_Layer: 0
   m_Name: Controller (left)
   m_TagString: Untagged
@@ -29972,11 +29807,11 @@ GameObject:
   m_Component:
   - component: {fileID: 1561572251}
   - component: {fileID: 114000010832659786}
+  - component: {fileID: 1561852222}
+  - component: {fileID: 114000010832659787}
   - component: {fileID: 114000010832659785}
   - component: {fileID: 630539508}
   - component: {fileID: 630539509}
-  - component: {fileID: 1561852222}
-  - component: {fileID: 114000010832659787}
   m_Layer: 0
   m_Name: Controller (right)
   m_TagString: Untagged
@@ -30027,7 +29862,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1561832013}
-  m_Mesh: {fileID: 108454097}
+  m_Mesh: {fileID: 1665780457}
 --- !u!1 &1562814951
 GameObject:
   m_ObjectHideFlags: 0
@@ -30094,7 +29929,7 @@ MeshRenderer:
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 4280377}
+  - {fileID: 1066846489}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -31376,7 +31211,7 @@ Transform:
   m_Children:
   - {fileID: 2038445944}
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1627962223
 MonoBehaviour:
@@ -31861,6 +31696,171 @@ RectTransform:
   m_AnchoredPosition: {x: 14.285713, y: -20}
   m_SizeDelta: {x: 28.571426, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!43 &1665780457
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 0000c03f0ad7233c000090bf000000000000803f0000803f0000803f00000000000000000000c0bf0ad7233c000090bf000000000000803f0000803f0000803f0000803f000000000000c0bf0ad7233c0000903f000000000000803f0000803f0000803f00000000000000000000c03f0ad7233c0000903f000000000000803f0000803f0000803f0000803f000000003333d33f0ad7233c3333a3bf000000000000803f0000803f00000000000000000000803f3333d3bf0ad7233c3333a3bf000000000000803f0000803f000000000000803f0000803f3333d3bf0ad7233c3333a33f000000000000803f0000803f00000000000000000000803f3333d33f0ad7233c3333a33f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1674193133
 GameObject:
   m_ObjectHideFlags: 0
@@ -34839,7 +34839,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1824309282
 MonoBehaviour:
@@ -40158,7 +40158,7 @@ MonoBehaviour:
   poseAction:
     actionPath: /actions/default/in/Pose
     needsReinit: 0
-  inputSource: 1
+  inputSource: 0
   origin: {fileID: 0}
   onTransformUpdated:
     m_PersistentCalls:
@@ -40224,7 +40224,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e6809e726998f694eb4376a56dae7055, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultPointerType: 0
 --- !u!114 &114000010832659785
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -40240,7 +40239,7 @@ MonoBehaviour:
   poseAction:
     actionPath: /actions/default/in/Pose
     needsReinit: 0
-  inputSource: 2
+  inputSource: 0
   origin: {fileID: 0}
   onTransformUpdated:
     m_PersistentCalls:
@@ -40270,7 +40269,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e6809e726998f694eb4376a56dae7055, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultPointerType: 1
 --- !u!114 &114000010832659787
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -45220,7 +45218,7 @@ Transform:
   - {fileID: 9090874683658339496}
   - {fileID: 2491205421301052135}
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2340584803070436714
 MonoBehaviour:
@@ -52206,7 +52204,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 5213886792327675102}
   m_Direction: 0
   m_Value: 1
-  m_Size: 1
+  m_Size: 0.9999999
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Assets/Scripts/Game/ModifiersManager.cs
+++ b/Assets/Scripts/Game/ModifiersManager.cs
@@ -232,6 +232,12 @@ public class ModifiersManager : MonoBehaviour
         StartCoroutine(WaitForCameraAndUpdate(eyePatch));
     }
 
+    public void SetPointerType(PointerType pointerType)
+    {
+        leftController.GetComponent<PointerTypeSelector>().ActivatePointer(pointerType);
+        rightController.GetComponent<PointerTypeSelector>().ActivatePointer(pointerType);
+    }
+
     public void SetHideWall(HideWall value) {
         if (hideWall == value) return;
         hideWall = value;

--- a/Assets/Scripts/Patterns/PatternInterface.cs
+++ b/Assets/Scripts/Patterns/PatternInterface.cs
@@ -273,6 +273,10 @@ public class PatternInterface : MonoBehaviour
             modifiersManager.SetMainController((ModifiersManager.ControllerSetup)System.Enum.Parse( typeof(ModifiersManager.ControllerSetup), tempValue));
             motorspaceManager.SetActiveMotorSpace(tempValue);
         }
+        if (action.TryGetValue("POINTERTYPE", out tempValue))
+        {
+            modifiersManager.SetPointerType((ModifiersManager.PointerType)System.Enum.Parse(typeof(ModifiersManager.PointerType), tempValue));
+        }
         if (action.TryGetValue("PRISM", out tempValue))
         {
             modifiersManager.SetPrismOffset(ParseFloat(tempValue));

--- a/Assets/Scripts/Pointers/Pointer.cs
+++ b/Assets/Scripts/Pointers/Pointer.cs
@@ -90,8 +90,8 @@ public abstract class Pointer : MonoBehaviour
     public class OnPointerShoot : UnityEvent { }
     public OnPointerShoot onPointerShoot;
 
-    // On Awake, gets the cursor object if there is one. Also connects the PositionUpdated function to the VR update event.
-    void Awake()
+    // On Init, gets the cursor object if there is one. Also connects the PositionUpdated function to the VR update event.
+    public void Init()
     {
         gameObject.GetComponent<SteamVR_Behaviour_Pose>().onTransformUpdated.AddListener(delegate{PositionUpdated();});
     }

--- a/Assets/Scripts/Pointers/PointerTypeSelector.cs
+++ b/Assets/Scripts/Pointers/PointerTypeSelector.cs
@@ -9,10 +9,7 @@ PointerTypeSelector manages which Pointer scripts should be enabled/disabled on 
 */
 public class PointerTypeSelector : MonoBehaviour
 {
-    [Tooltip("DefaultPointerType is not switchable while playing: must be set correctly before running.")]
-    [SerializeField] PointerType defaultPointerType = PointerType.BasicPointer;
-
-    private Dictionary<PointerType, Pointer> pointerList = new Dictionary<PointerType, Pointer>();
+    private Dictionary<ModifiersManager.PointerType, Pointer> pointerList = new Dictionary<ModifiersManager.PointerType, Pointer>();
     private SteamVR_Behaviour_Pose behaviour_Pose;
 
     void Start()
@@ -23,7 +20,7 @@ public class PointerTypeSelector : MonoBehaviour
         // Populate the pointerList dictionary with pointers found in the GameObject
         foreach (Pointer pointer in pointers)
         {
-            if (Enum.TryParse(pointer.GetType().Name, out PointerType pointerType))
+            if (Enum.TryParse(pointer.GetType().Name, out ModifiersManager.PointerType pointerType))
             {
                 pointerList[pointerType] = pointer;
             }
@@ -34,10 +31,10 @@ public class PointerTypeSelector : MonoBehaviour
         }
 
         // Activate the default pointer type at the start
-        ActivatePointer(defaultPointerType);
+        ActivatePointer(ModifiersManager.defaultPointerType);
     }
 
-    public void ActivatePointer(PointerType pointerType)
+    public void ActivatePointer(ModifiersManager.PointerType pointerType)
     {
         // Disable all pointers before activating the selected one
         pointerList.Values.ToList().ForEach(pointer => pointer.enabled = false);
@@ -46,6 +43,7 @@ public class PointerTypeSelector : MonoBehaviour
         if (pointerList.TryGetValue(pointerType, out Pointer pointer))
         {
             pointer.enabled = true;
+            pointer.Init();
             behaviour_Pose.inputSource = pointer.Controller; // Change the tracking device for the pointer
         }
         else
@@ -53,12 +51,10 @@ public class PointerTypeSelector : MonoBehaviour
             Debug.LogError($"Pointer type {pointerType} not found.");
         }
     }
-}
 
-
-// Important: Ensure to update the PointerType enum when new pointer type script is added /!\
-public enum PointerType
-{
-    BasicPointer,
-    EMGPointer
+    public Pointer GetActivePointer()
+    {
+        // Return the currently active pointer
+        return pointerList.Values.FirstOrDefault(pointer => pointer.enabled);
+    }
 }

--- a/Assets/StreamingAssets/SteamVR/bindings_vive_controller.json
+++ b/Assets/StreamingAssets/SteamVR/bindings_vive_controller.json
@@ -1,5 +1,7 @@
 {
-   "app_key" : "application.generated.unity.steamvr.exe",
+   "action_manifest_version" : 0,
+   "alias_info" : {},
+   "app_key" : "application.generated.unity.whack_a_mole_vr.exe",
    "bindings" : {
       "/actions/buggy" : {
          "sources" : [
@@ -250,7 +252,11 @@
          ]
       }
    },
+   "category" : "steamvr_input",
    "controller_type" : "vive_controller",
    "description" : "",
-   "name" : "vive_controller"
+   "interaction_profile" : "",
+   "name" : "vive_controller",
+   "options" : {},
+   "simulated_actions" : []
 }


### PR DESCRIPTION
Now, ModifiersManager can handle severals Pointer type per controller.
New method SetPointerType added to the ModifiersManager class to activate specific pointer types for controllers.
The PatternInterface class now handles the "POINTERTYPE" action, parsing it into a ModifiersManager.PointerType enum and invoking the SetPointerType method accordingly.