### PR TITLE
Fixed Wall size logging

### DIFF
--- a/Assets/Scripts/Game/WallManager.cs
+++ b/Assets/Scripts/Game/WallManager.cs
@@ -199,8 +199,7 @@ public class WallManager : MonoBehaviour
     private void UpdateWallLogs()
     {
         MeshRenderer mesh = GetComponent<MeshRenderer>();
-
-        loggerNotifier.InitPersistentEventParameters(new Dictionary<string, object>(){
+        Dictionary<string, object> data = new Dictionary<string, object>(){
             {"WallRowCount", rowCount},
             {"WallColumnCount", columnCount},
             {"WallSizeX", wallSize.x},
@@ -217,7 +216,10 @@ public class WallManager : MonoBehaviour
             {"WallCenterZ", meshCenter.z},
             {"WallCurveRatioX", xCurveRatio},
             {"WallCurveRatioY", yCurveRatio}
-        });
+        };
+        loggerNotifier.InitPersistentEventParameters(data);
+
+        loggerNotifier.NotifyLogger("Wall Updated", EventLogger.EventType.WallEvent, data);
     }
 
     void OnValidate()

--- a/Assets/Scripts/Logging/EventLogger.cs
+++ b/Assets/Scripts/Logging/EventLogger.cs
@@ -117,6 +117,10 @@ public class EventLogger : MonoBehaviour
     {
         switch (datas["Event"])
         {
+            case "Wall Created":
+            case "Wall Updated":
+                SaveEventDatas(datas);
+                break;
             case "Game Started":
                 trackerHub.StartTrackers();
                 gameId = GenerateUid();


### PR DESCRIPTION
Fixed the non-apparition of the wall bound in the log file as requested in #282. Bound will now properly show when a Wall Update event is logged. Also fixed the non-sending of Wall Update events.