### PR TITLE
Logging issues fix

### DIFF
--- a/Assets/LoggingManager/WriteToCSV.cs
+++ b/Assets/LoggingManager/WriteToCSV.cs
@@ -95,7 +95,6 @@ public class WriteToCSV
                 file.Write(dataString);
             }
         }
-        GameDirector.currentPlayPeriod = "PreGame";
 
         writeStopwatch.Stop();
         TimeSpan writeTs = writeStopwatch.Elapsed;

--- a/Assets/LoggingManager/WriteToCSV.cs
+++ b/Assets/LoggingManager/WriteToCSV.cs
@@ -44,7 +44,7 @@ public class WriteToCSV
     //Writes all the logs into the file at the given filepath
     public void WriteAll(Action callback)
     {
-        //This part has to be executed in the main Thread 
+        //This part has to be executed in the main Thread
         if (logStore.CurrentLogRow.Count != 0)
         {
             logStore.EndRow();
@@ -78,7 +78,7 @@ public class WriteToCSV
         Stopwatch writeStopwatch = new Stopwatch();
         writeStopwatch.Start();
 
-        try { 
+        try {
             using (var file = new StreamWriter(filePath, true))
             {
                 file.WriteLine(headers);
@@ -95,6 +95,7 @@ public class WriteToCSV
                 file.Write(dataString);
             }
         }
+        GameDirector.currentPlayPeriod = "PreGame";
 
         writeStopwatch.Stop();
         TimeSpan writeTs = writeStopwatch.Elapsed;
@@ -102,5 +103,5 @@ public class WriteToCSV
             writeTs.Seconds, writeTs.Milliseconds);
         Debug.Log(logStore.Label + " logs wrote to file in " + writeElapsedTime);
     }
-
+    
 }

--- a/Assets/Scripts/Game/GameDirector.cs
+++ b/Assets/Scripts/Game/GameDirector.cs
@@ -88,6 +88,8 @@ public class GameDirector : MonoBehaviour
     [SerializeField]
     public TestChangeEvent testChanged = new TestChangeEvent();
 
+    public static string currentPlayPeriod = "PreGame";
+
     private Dictionary<string, float> difficultySettings;
     private Coroutine spawnTimer;
     private float currentGameTimeLeft;
@@ -225,6 +227,7 @@ public class GameDirector : MonoBehaviour
         UpdateState(GameState.Playing);
         Mole.ResetMoleOccurrenceIDCounter();
         if (gazeRecorder != null) gazeRecorder.StartRecording();
+        currentPlayPeriod = "Game";
         loggerNotifier.NotifyLogger("Game Started", EventLogger.EventType.GameEvent, new Dictionary<string, object>()
         {
             {"GameState", System.Enum.GetName(typeof(GameDirector.GameState), gameState)}
@@ -252,6 +255,7 @@ public class GameDirector : MonoBehaviour
             {"testID", testId}
         };
         loggingManager.Log("Meta", metaLog);
+        currentPlayPeriod = "PostGame";
         loggerNotifier.NotifyLogger("Game Stopped", EventLogger.EventType.GameEvent, new Dictionary<string, object>()
         {
             {"GameState", System.Enum.GetName(typeof(GameDirector.GameState), gameState)}
@@ -532,6 +536,7 @@ public class GameDirector : MonoBehaviour
             {"TestID", testId}
         };
         loggingManager.Log("Meta", metaLog);
+        currentPlayPeriod = "PostGame";
         loggerNotifier.NotifyLogger("Game Finished", EventLogger.EventType.GameEvent, new Dictionary<string, object>()
         {
             {"GameState", System.Enum.GetName(typeof(GameDirector.GameState), gameState)}

--- a/Assets/Scripts/Game/GameDirector.cs
+++ b/Assets/Scripts/Game/GameDirector.cs
@@ -223,6 +223,7 @@ public class GameDirector : MonoBehaviour
         }
 
         UpdateState(GameState.Playing);
+        Mole.ResetMoleOccurrenceIDCounter();
         if (gazeRecorder != null) gazeRecorder.StartRecording();
         loggerNotifier.NotifyLogger("Game Started", EventLogger.EventType.GameEvent, new Dictionary<string, object>()
         {

--- a/Assets/Scripts/Game/GameDirector.cs
+++ b/Assets/Scripts/Game/GameDirector.cs
@@ -88,7 +88,7 @@ public class GameDirector : MonoBehaviour
     [SerializeField]
     public TestChangeEvent testChanged = new TestChangeEvent();
 
-    public static string currentPlayPeriod = "PreGame";
+    public static string currentPlayPeriod = null;
 
     private Dictionary<string, float> difficultySettings;
     private Coroutine spawnTimer;
@@ -131,6 +131,12 @@ public class GameDirector : MonoBehaviour
         modifiersManager = FindObjectOfType<ModifiersManager>();
         gameDefaultDuration = gameDuration;
         constraint = FindObjectOfType<Constraint>();
+        initGamePeriod();
+    }
+
+    public static void initGamePeriod()
+    {
+        currentPlayPeriod = "PreGame";
     }
 
     private void Update()

--- a/Assets/Scripts/Game/WallGenerator.cs
+++ b/Assets/Scripts/Game/WallGenerator.cs
@@ -123,6 +123,7 @@ public class WallGenerator : MonoBehaviour
                     {"TargetPositionWorldZ", newTargetSpawner.transform.position.z},
                     {"TargetIndexX", (int)Mathf.Floor(newTargetSpawner.GetId()/100)},
                     {"TargetIndexY", newTargetSpawner.GetId() % 100},
+                    {"PlayPeriod", GameDirector.currentPlayPeriod}
                 });
             }
         }
@@ -327,7 +328,7 @@ public class WallGenerator : MonoBehaviour
         {
             outlineRenderer.material = outlineMaterial;
         }
-        
+    
         // Apply the outline color directly to the material
         if (outlineRenderer.material != null)
         {

--- a/Assets/Scripts/Logging/EventLogger.cs
+++ b/Assets/Scripts/Logging/EventLogger.cs
@@ -34,6 +34,8 @@ public class EventLogger : MonoBehaviour
     private Dictionary<string, object> currentMoleLog = new Dictionary<string, object>();
     private Dictionary<string, Dictionary<int, string>> logs = new Dictionary<string, Dictionary<int, string>>();
     private Dictionary<string, string> defaultValues = new Dictionary<string, string>();
+    private Vector3 lastMolePosition = Vector3.zero;
+
     private int logCount = 0;
     private string email = "";
     private LoggingManager loggingManager;
@@ -125,6 +127,7 @@ public class EventLogger : MonoBehaviour
                 trackerHub.StartTrackers();
                 gameId = GenerateUid();
                 //InitFile();
+                ResetDistanceFromLastMole();
                 SaveEventDatas(datas);
                 break;
             case "Game Stopped":
@@ -137,6 +140,7 @@ public class EventLogger : MonoBehaviour
                 break;
             case "Mole Spawned":
                 UpdateCurrentMoleLog(datas);
+                UpdateDistToLastMole(datas);
                 SaveEventDatas(datas, true, true);
                 break;
             case "DistractorRight Mole Spawned":
@@ -266,6 +270,27 @@ public class EventLogger : MonoBehaviour
 
         loggingManager.Log("Event", datas);
     }
+
+    private void UpdateDistToLastMole(Dictionary<string, object> datas) {
+        Vector3 currentMolePosition = new Vector3(
+            (float)datas["MolePositionWorldX"],
+            (float)datas["MolePositionWorldY"],
+            (float)datas["MolePositionWorldZ"]
+        );
+
+        datas.Add("DistFromLastMole", GetDistanceFromLastMole(currentMolePosition));
+
+        lastMolePosition = currentMolePosition;
+    }
+
+    private float GetDistanceFromLastMole(Vector3 currentPosition) {
+        return Vector3.Distance(currentPosition, lastMolePosition);
+    }
+
+    private void ResetDistanceFromLastMole() {
+        lastMolePosition = Vector3.zero;
+    }
+
 
     // // Generates a "logs" row (see class description) from the given datas. Adds mandatory parameters and
     // // the PersistentEvents parameters to the row when generating it.

--- a/Assets/Scripts/Logging/EventLogger.cs
+++ b/Assets/Scripts/Logging/EventLogger.cs
@@ -155,7 +155,7 @@ public class EventLogger : MonoBehaviour
                 break;
             case "Mole Hit":
             case "Mole Expired":
-                UpdateCurrentMoleLog(datas);
+                UpdateCurrentMoleLog(datas); // to remove
                 SaveEventDatas(datas, true, true);
                 break;
             case "DistractorRight Mole Expired":

--- a/Assets/Scripts/Logging/EventLogger.cs
+++ b/Assets/Scripts/Logging/EventLogger.cs
@@ -155,7 +155,6 @@ public class EventLogger : MonoBehaviour
                 break;
             case "Mole Hit":
             case "Mole Expired":
-                UpdateCurrentMoleLog(datas); // to remove
                 SaveEventDatas(datas, true, true);
                 break;
             case "DistractorRight Mole Expired":

--- a/Assets/Scripts/Logging/EventLogger.cs
+++ b/Assets/Scripts/Logging/EventLogger.cs
@@ -258,6 +258,7 @@ public class EventLogger : MonoBehaviour
             }
         }
 
+        datas["PlayPeriod"] = GameDirector.currentPlayPeriod;
         datas["TimeSinceLastEvent"] = GetPreviousEventTimeDiff().ToString("0.0000").Replace(",", ".");
         datas["PupilTime"] = timeSync != null ? timeSync.GetPupilTimestamp().ToString().Replace(",", ".") : "NULL";
         datas["UnityToPupilTimeOffset"] = timeSync != null ? timeSync.UnityToPupilTimeOffset.ToString().Replace(",", ".") : "NULL";

--- a/Assets/Scripts/Logging/WallStateTracker.cs
+++ b/Assets/Scripts/Logging/WallStateTracker.cs
@@ -1,14 +1,16 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 /*
 Class keeping track of the state of the wall, meaning the state of the Mole. Keeps a list of the activated moles to
-calculate the closest active mole when a laser is shot and misses.
+calculate the closest active mole when a laser is shot and misses. Also tracks active mole IDs ordered by expiration time.
 */
 
 public class WallStateTracker : MonoBehaviour
 {
     private List<Mole> activeMoles = new List<Mole>();
+    private Dictionary<int, float> activeMoleIDsWithExpiration = new Dictionary<int, float>();
 
     void Start()
     {
@@ -39,6 +41,7 @@ public class WallStateTracker : MonoBehaviour
         Dictionary<int, TargetSpawner> targetSpawners = wallInfo.targetSpawners;
         if (isActivating)
         {
+            activeMoleIDsWithExpiration.Clear();
             foreach (TargetSpawner targetSpawner in targetSpawners.Values)
             {
                 targetSpawner.GetUpdateEvent().AddListener(MoleStateUpdate);
@@ -47,19 +50,23 @@ public class WallStateTracker : MonoBehaviour
         else
         {
             activeMoles.Clear();
+            activeMoleIDsWithExpiration.Clear();
         }
     }
 
-    // Function called through an event whan a Mole's state changes.
+    // Function called through an event when a Mole's state changes.
     public void MoleStateUpdate(bool isActivating, Mole concernedMole)
     {
         if (isActivating)
         {
             activeMoles.Add(concernedMole);
+            float expirationTime = Time.time + concernedMole.GetLifeTime();
+            activeMoleIDsWithExpiration[concernedMole.GetMoleOccurrenceID()] = expirationTime;
         }
         else
         {
             activeMoles.Remove(concernedMole);
+            activeMoleIDsWithExpiration.Remove(concernedMole.GetMoleOccurrenceID());
         }
     }
 }

--- a/Assets/Scripts/Moles/Mole.cs
+++ b/Assets/Scripts/Moles/Mole.cs
@@ -53,6 +53,8 @@ public abstract class Mole : MonoBehaviour
     private LoggerNotifier loggerNotifier;
     private bool isOnDisabledCoolDown = false;
     private bool performanceFeedback = true;
+    private int moleOccurrenceID = -1;
+    private static int moleOccurrenceIDCounter = 0;
 
     protected States state = States.Disabled;
     protected MoleOutcome moleOutcome = MoleOutcome.Valid;
@@ -78,6 +80,7 @@ public abstract class Mole : MonoBehaviour
         // Initialization of the LoggerNotifier. Here we will only raise Event, and we will use a function to pass and update
         // certain parameters values every time we raise an event (UpdateLogNotifierGeneralValues). We don't set any starting values.
         loggerNotifier = new LoggerNotifier(UpdateLogNotifierGeneralValues, new Dictionary<string, string>(){
+            {"MoleOccurenceID", "NULL"},
             {"MolePositionWorldX", "NULL"},
             {"MolePositionWorldY", "NULL"},
             {"MolePositionWorldZ", "NULL"},
@@ -150,6 +153,26 @@ public abstract class Mole : MonoBehaviour
     {
         return id;
     }
+
+    public int GetMoleOccurrenceID()
+    {
+        return moleOccurrenceID;
+    }
+
+    public float GetLifeTime()
+    {
+        return lifeTime;
+    }
+
+    public float GetActivatedTimeLeft()
+    {
+        return activatedTimeLeft;
+    }
+
+    public static void ResetMoleOccurrenceIDCounter()
+    {
+        moleOccurrenceIDCounter = 0;
+    }
     public string GetValidationArg() => validationArg;
     public void SetValidationArg(string data) => validationArg = data;
 
@@ -184,6 +207,7 @@ public abstract class Mole : MonoBehaviour
         lifeTime = enabledLifeTime;
         expiringTime = expiringDuration;
         spawnOrder = moleSpawnOrder;
+        moleOccurrenceID = moleOccurrenceIDCounter++;
         ChangeState(States.Enabling);
     }
 
@@ -442,6 +466,7 @@ public abstract class Mole : MonoBehaviour
         string MoleIndexY = moleId.Substring(5, 2);
 
         return new LogEventContainer(new Dictionary<string, object>(){
+            {"MoleOccurenceID", moleOccurrenceID},
             {"MolePositionWorldX", transform.position.x},
             {"MolePositionWorldY", transform.position.y},
             {"MolePositionWorldZ", transform.position.z},

--- a/Assets/Scripts/Pointers/BasicPointer/BasicPointer.cs
+++ b/Assets/Scripts/Pointers/BasicPointer/BasicPointer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -106,9 +106,12 @@ public class BasicPointer : Pointer
                     if (hover == string.Empty)
                     {
                         hover = mole.GetId().ToString();
+                        loggerNotifier.InitPersistentEventParameters(new Dictionary<string, object>(){
+                            {"ControllerHover", hover}
+                        });
+
                         loggerNotifier.NotifyLogger("Pointer Hover Begin", EventLogger.EventType.PointerEvent, new Dictionary<string, object>()
                             {
-                                {"ControllerHover", hover},
                                 {"ControllerName", gameObject.name}
                             });
                     }
@@ -162,9 +165,12 @@ public class BasicPointer : Pointer
     {
         if (hover != string.Empty)
         {
+            loggerNotifier.InitPersistentEventParameters(new Dictionary<string, object>(){
+                {"ControllerHover", "NULL"}
+            });
+
             loggerNotifier.NotifyLogger("Pointer Hover End", EventLogger.EventType.PointerEvent, new Dictionary<string, object>()
             {
-                {"ControllerHover", hover},
                 {"ControllerName", gameObject.name}
             });
             hover = "";

--- a/Assets/Scripts/Pointers/BubbleDisplay.cs
+++ b/Assets/Scripts/Pointers/BubbleDisplay.cs
@@ -169,6 +169,7 @@ public class BubbleDisplay : MonoBehaviour
                 {
                     {"Event", "Pointer Inside MotorSpace"},
                     {"EventType", "MotorSpaceEvent"},
+                    {"PlayPeriod", GameDirector.currentPlayPeriod},
                 });
                 if (soundManager != null)
                 {
@@ -200,6 +201,7 @@ public class BubbleDisplay : MonoBehaviour
                 {
                     {"Event", "Pointer Outside MotorSpace"},
                     {"EventType", "MotorSpaceEvent"},
+                    {"PlayPeriod", GameDirector.currentPlayPeriod},
                 });
                 if (soundManager != null)
                 {

--- a/Assets/Scripts/Pointers/EMGPointer/EMGPointer.cs
+++ b/Assets/Scripts/Pointers/EMGPointer/EMGPointer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -110,9 +110,12 @@ public class EMGPointer : Pointer
         {
             moleHoveringGesture = mole.GetValidationArg();
 
+            loggerNotifier.InitPersistentEventParameters(new Dictionary<string, object>(){
+                {"ControllerHover", mole.GetId().ToString()}
+            });
+
             loggerNotifier.NotifyLogger("Pointer Hover Begin", EventLogger.EventType.PointerEvent, new Dictionary<string, object>()
             {
-                {"ControllerHover", mole.GetId().ToString()},
                 {"ControllerName", gameObject.name}
             });
         }
@@ -125,9 +128,12 @@ public class EMGPointer : Pointer
 
         moleHoveringGesture = DEFAULT_GESTURE;
 
+        loggerNotifier.InitPersistentEventParameters(new Dictionary<string, object>(){
+            {"ControllerHover", "NULL"}
+        });
+
         loggerNotifier.NotifyLogger("Pointer Hover End", EventLogger.EventType.PointerEvent, new Dictionary<string, object>()
         {
-            {"ControllerHover", mole.name},
             {"ControllerName", gameObject.name}
         });
     }

--- a/Assets/Scripts/Pointers/LaserMapper.cs
+++ b/Assets/Scripts/Pointers/LaserMapper.cs
@@ -267,6 +267,7 @@ public class LaserMapper : MonoBehaviour
             {"MotorSpaceGainX", gainX},
             {"MotorSpaceGainY", gainY},
             {"MotorSpaceName", gameObject.name},
+            {"PlayPeriod", GameDirector.currentPlayPeriod}
         });
     }
 

--- a/Assets/Scripts/UI/TherapistPanel/GameStateContainer.cs
+++ b/Assets/Scripts/UI/TherapistPanel/GameStateContainer.cs
@@ -84,6 +84,7 @@ public class GameStateContainer : MonoBehaviour
         gameStateText.text = "Uploading Data..";
         loggingManager.SaveAllLogs(clear: true);
         loggingManager.NewFilestamp();
+        GameDirector.initGamePeriod();
     }
 
     public void OnDiscardData()
@@ -96,6 +97,7 @@ public class GameStateContainer : MonoBehaviour
         gameStateText.text = "Hold on..";
         loggingManager.SaveAllLogs(targetType: TargetType.CSV, clear: true);
         loggingManager.NewFilestamp();
+        GameDirector.initGamePeriod();
         Reset();
     }
 


### PR DESCRIPTION
Added/Fixed various issues on Event Logging:

- Added MoleOccurrenceId (see if redundant with MoleID since it is now under a format that tracks mole in time-wise (format is currently broken, to be fixed))
- Added DistFromLastMole which logs the euclidean distance from the previous mole on spawn
- Added a PlayPeriod (PreGame/Game/PostGame) state log changing on Game Started/Stopped/Finished events

- Fixed ControllerHover to now only log the id of the mole hovered from Controller Hover Begin (included) to Controller Hover End (excluded) (more precisely Pointer Shoot and Mole Hit events are logged one frame before Controller Hover End and do not show the id of the mole hovered)
- Fixed CurrentMoleToHit (e. g. CurrentMoleToHitId, CurrentMoleToHitIndexX, etc...) to not be refreshed by an expiring mole anymore