### PR TITLE
Fix data button logic

### DIFF
--- a/Assets/Scenes/SetupScene.unity
+++ b/Assets/Scenes/SetupScene.unity
@@ -49114,9 +49114,12 @@ MonoBehaviour:
   m_CharacterLimit: 4
   m_OnSubmit:
     m_PersistentCalls:
+      m_Calls: []
+  m_OnDidEndEdit:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2477977885611635136}
-        m_TargetAssemblyTypeName: 
+        m_TargetAssemblyTypeName: ButtonTextController, Assembly-CSharp
         m_MethodName: OnInputEndEdit
         m_Mode: 1
         m_Arguments:
@@ -49127,9 +49130,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  m_OnDidEndEdit:
-    m_PersistentCalls:
-      m_Calls: []
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -53974,9 +53974,12 @@ MonoBehaviour:
   m_CharacterLimit: 4
   m_OnSubmit:
     m_PersistentCalls:
+      m_Calls: []
+  m_OnDidEndEdit:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 4093640881905353660}
-        m_TargetAssemblyTypeName: 
+        m_TargetAssemblyTypeName: ButtonTextController, Assembly-CSharp
         m_MethodName: OnInputEndEdit
         m_Mode: 1
         m_Arguments:
@@ -53987,9 +53990,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  m_OnDidEndEdit:
-    m_PersistentCalls:
-      m_Calls: []
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -55537,7 +55537,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 5213886792327675102}
   m_Direction: 0
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.9999998
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -61812,9 +61812,12 @@ MonoBehaviour:
   m_CharacterLimit: 4
   m_OnSubmit:
     m_PersistentCalls:
+      m_Calls: []
+  m_OnDidEndEdit:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 8184999348443934463}
-        m_TargetAssemblyTypeName: 
+        m_TargetAssemblyTypeName: ButtonTextController, Assembly-CSharp
         m_MethodName: OnInputEndEdit
         m_Mode: 1
         m_Arguments:
@@ -61825,9 +61828,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  m_OnDidEndEdit:
-    m_PersistentCalls:
-      m_Calls: []
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/Game/ModifiersManager.cs
+++ b/Assets/Scripts/Game/ModifiersManager.cs
@@ -634,7 +634,6 @@ public class ModifiersManager : MonoBehaviour
 
         bool enableRight = (controllerType == ControllerSetup.Right || controllerType == ControllerSetup.Both);
         bool enableLeft = (controllerType == ControllerSetup.Left || controllerType == ControllerSetup.Both);
-        Debug.Log("Right controller: " + enableRight + " | Left controller: " + enableLeft);
 
         if (enableRight)
         {

--- a/Assets/Scripts/UI/ButtonTextController.cs
+++ b/Assets/Scripts/UI/ButtonTextController.cs
@@ -81,18 +81,15 @@ public class ButtonTextController : UiNotifier
     // On hover enter, activates the "edit" text.
     public void OnMouseEnter()
     {
-        if (!activated) return;
+        if (!activated || edit) return;
         FocusEdit();
     }
 
     // On hover leave, if the input field is not being edited, activates the information text.
     public void OnMouseLeave()
     {
-        if (!activated) return;
-        if (!edit)
-        {
-            FocusInfo();
-        }
+        if (!activated || edit) return;
+        FocusInfo();
     }
 
     // On end of the edition of the input field, checks the input value, activates the information text and notifies any listener that its value has changed.


### PR DESCRIPTION
Fixes the data button's logic to prevent them from breaking, also cleans up code and removes a useless Log in ModifiersManager.

See #402 for details on the issue.