### PR TITLE
Added Score attached to moles

### DIFF
--- a/Assets/Scripts/Game/TargetSpawner.cs
+++ b/Assets/Scripts/Game/TargetSpawner.cs
@@ -50,7 +50,7 @@ public class TargetSpawner : MonoBehaviour
         if (performanceFeedback.HasValue) parameters.performanceFeedback = performanceFeedback.Value;
     }
 
-    public Mole SpawnMole(Mole.MoleType type, Mole.MoleOutcome outcome, float lifeTime, float expiringDuration, int spawnOrder, string validationArg = "")
+    public Mole SpawnMole(Mole.MoleType type, Mole.MoleOutcome outcome, float lifeTime, float expiringDuration, int spawnOrder, int moleScore, string validationArg = "")
     {
         if (_lock)
         {
@@ -68,6 +68,7 @@ public class TargetSpawner : MonoBehaviour
         }
 
         currentMole.Init(this);
+        currentMole.SetMoleScore(moleScore);
         currentMole.SetNormalizedIndex(parameters.normalizedIndex);
         currentMole.SetValidationArg(validationArg);
         currentMole.SetPerformanceFeedback(parameters.performanceFeedback);
@@ -76,7 +77,7 @@ public class TargetSpawner : MonoBehaviour
         currentMole.Enable(lifeTime, expiringDuration, type, outcome, spawnOrder); // TODO future update, check if enable still needed (or change to init)
         stateUpdateEvent.Invoke(true, currentMole);
 
-      
+
 
         _lock = true;
         return currentMole;

--- a/Assets/Scripts/Game/WallManager.cs
+++ b/Assets/Scripts/Game/WallManager.cs
@@ -315,17 +315,18 @@ public class WallManager : MonoBehaviour
         return wallInfo;
     }
 
-    // Activates a random Mole for a given lifeTime and set if is fake or not
+    // Activates a random Mole for a given lifeTime, set if it is fake or not, and assign a random score.
     public void ActivateRandomMole(float lifeTime, float moleExpiringDuration, Mole.MoleType type, Mole.MoleOutcome outcome)
     {
         if (!active) return;
 
-        GetRandomFreeSpawner().SpawnMole(type, outcome, lifeTime, moleExpiringDuration, moleCount);
+        int randomScore = Random.Range(50, 501);
+        GetRandomFreeSpawner().SpawnMole(type, outcome, lifeTime, moleExpiringDuration, moleCount, randomScore);
         moleCount++;
     }
 
     // Activates a specific Mole for a given lifeTime and set if is fake or not
-    public Mole CreateMole(int targetSpawnId, float lifeTime, float moleExpiringDuration, Mole.MoleType type, Mole.MoleOutcome outcome, string validationArg = "")
+    public Mole CreateMole(int targetSpawnId, float lifeTime, float moleExpiringDuration, Mole.MoleType type, Mole.MoleOutcome outcome, int moleScore, string validationArg = "")
     {
         if (!active) return null;
         if (!targetSpawners.ContainsKey(targetSpawnId))
@@ -334,7 +335,7 @@ public class WallManager : MonoBehaviour
             return null;
         }
 
-        targetSpawners[targetSpawnId].SpawnMole(type, outcome, lifeTime, moleExpiringDuration, spawnOrder, validationArg); 
+        targetSpawners[targetSpawnId].SpawnMole(type, outcome, lifeTime, moleExpiringDuration, spawnOrder, moleScore, validationArg);
         moleCount++;
 
         return targetSpawners[targetSpawnId].GetCurrentMole();

--- a/Assets/Scripts/Moles/Mole.cs
+++ b/Assets/Scripts/Moles/Mole.cs
@@ -61,6 +61,7 @@ public abstract class Mole : MonoBehaviour
     protected MoleType moleType = MoleType.SimpleTarget;
     protected string validationArg = ""; // Not used by default: can be used to store data for specific needs (e.g. gesture type for gesture moles)
 
+    protected int moleScore = 0;
 
     public virtual void Init(TargetSpawner parentSpawner) // Needed when the Mole is instantiated, to avoid calling a method before the Awake and Start methods are called.
     {
@@ -97,6 +98,7 @@ public abstract class Mole : MonoBehaviour
             {"MoleIndexY", "NULL"},
             {"MoleNormalizedIndexX", "NULL"},
             {"MoleNormalizedIndexY", "NULL"},
+            {"MoleScore", "NULL"},
             {"MoleSurfaceHitLocationX", "NULL"},
             {"MoleSurfaceHitLocationY", "NULL"}
         });
@@ -175,7 +177,8 @@ public abstract class Mole : MonoBehaviour
     }
     public string GetValidationArg() => validationArg;
     public void SetValidationArg(string data) => validationArg = data;
-
+    public void SetMoleScore(int score) => moleScore = score;
+    public int GetMoleScore() => moleScore;
     public States GetState()
     {
         return state;
@@ -475,6 +478,7 @@ public abstract class Mole : MonoBehaviour
             {"MolePositionLocalZ", transform.localPosition.z},
             {"MoleSize", (this.GetComponentsInChildren<Renderer>()[0].bounds.max.x - this.GetComponentsInChildren<Renderer>()[0].bounds.min.x)},
             {"MoleLifeTime", lifeTime},
+            {"MoleScore", moleScore},
             {"MoleType", moleType},
             {"MoleId", moleId},
             {"MoleSpawnOrder", spawnOrder.ToString("0000")},

--- a/Assets/Scripts/Patterns/PatternInterface.cs
+++ b/Assets/Scripts/Patterns/PatternInterface.cs
@@ -126,6 +126,7 @@ public class PatternInterface : MonoBehaviour
                         action["X"], action["Y"],
                         action["LIFETIME"], moleType,
                         Mole.MoleOutcome.Valid,
+                        action.ContainsKey("SCORE") ? action["SCORE"] : "0",
                         action.ContainsKey("VALIDATION") ? action["VALIDATION"] : ""
                     );
 
@@ -256,10 +257,10 @@ public class PatternInterface : MonoBehaviour
     }
 
     // Spawns a Mole
-    private void SetMole(string xIndex, string yIndex, string lifeTime, Mole.MoleType moleType, Mole.MoleOutcome outcome, string validationArg = "")
+    private void SetMole(string xIndex, string yIndex, string lifeTime, Mole.MoleType moleType, Mole.MoleOutcome outcome,  string moleScore = "0", string validationArg = "")
     {
         int targetSpawnId = ((int.Parse(xIndex)) * 100) + (int.Parse(yIndex));
-        Mole mole = wallManager.CreateMole(targetSpawnId, ParseFloat(lifeTime), gameDirector.GetMoleExpiringDuration(), moleType, outcome, validationArg);
+        Mole mole = wallManager.CreateMole(targetSpawnId, ParseFloat(lifeTime), gameDirector.GetMoleExpiringDuration(), moleType, outcome, ParseInteger(moleScore), validationArg);
         molesList[targetSpawnId] = mole;
         if (mole.IsValid()) AddToTargetsList(mole);
     }
@@ -384,6 +385,11 @@ public class PatternInterface : MonoBehaviour
     private float ParseFloat(string value)
     {
         return float.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private int ParseInteger(string value)
+    {
+        return int.Parse(value, CultureInfo.InvariantCulture);
     }
 
     // Sets the outline visibility

--- a/Assets/Scripts/Pointers/Pointer.cs
+++ b/Assets/Scripts/Pointers/Pointer.cs
@@ -195,6 +195,7 @@ public abstract class Pointer : MonoBehaviour
             case Mole.MolePopAnswer.Ok:
                 PlayShoot(correctHit: true);
                 soundManager.PlaySound(gameObject, SoundManager.Sound.greenMoleHit);
+                Debug.Log($"Mole hit. Score: {mole.GetMoleScore()}");
                 break;
 
             case Mole.MolePopAnswer.Fake:
@@ -318,6 +319,7 @@ public abstract class Pointer : MonoBehaviour
                     case Mole.MolePopAnswer.Ok:
                         PlayShoot(true);
                         soundManager.PlaySound(gameObject, SoundManager.Sound.greenMoleHit);
+                        Debug.Log($"Mole hit. Score: {mole.GetMoleScore()}");
                         break;
 
                     case Mole.MolePopAnswer.Fake:


### PR DESCRIPTION
Added a score value attached to each mole that will be used for future scoring feature. By default mole score is set to 0.
On Random moles, the score is a random value between 50 and 500 In patterns, to set the value of a mole, use the SCORE keyword. Also added a temporary console log to be removed when score will be in use